### PR TITLE
Update Bootstrap Icons version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -652,9 +652,9 @@
       "integrity": "sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ=="
     },
     "bootstrap-icons": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.2.2.tgz",
-      "integrity": "sha512-7rFICA7E/CgYLvu8zYtd2wMZYhYPQ0GtogZtQyJz/3melCGeQ76qas5wItIEwiUNmtZWg2SP2p8Ekxy3Nk7vvg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.3.0.tgz",
+      "integrity": "sha512-w6zQ93p626zmPDqDtET7VdB9EkoDtfmCBV53hunjntoCke6X5LafXf6TxPAP+ImjRAhhxAyA/sjzQnHBY0uoiQ=="
     },
     "boxen": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "bootstrap": "^4.5.3",
-    "bootstrap-icons": "^1.2.2",
+    "bootstrap-icons": "^1.3.0",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1"
   },


### PR DESCRIPTION
Thinking we can ship this along with a v4.6.0 update? Or should we go with a v1.3.1 update to include?

/cc @XhmikosR 