### PR TITLE
CI: remove redundant CI env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on: [push, pull_request]
 
 env:
-  CI: true
   FORCE_COLOR: 2
 
 jobs:


### PR DESCRIPTION
This is already set by the runner