### PR TITLE
Update tools: Vite - hot reloads, production rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## About
 
-The **Bootstrap npm starter** is a GitHub template repository for quickly creating new [Bootstrap](https://getbootstrap.com)-powered npm projects. Click `Use this template` above, or clone/download it as your own Bootstrap prototyping sandbox.
+The **Bootstrap npm starter + Vite** is a GitHub template repository for quickly creating new [Bootstrap](https://getbootstrap.com)-powered npm projects. Click `Use this template` above, or clone/download it as your own Bootstrap prototyping sandbox.
 
 Includes support for importing Bootstrap via `node_modules`, adding your own customizations, and compiling CSS and JS for production. It also includes more advanced features for streamlinoing compiled code with Purge CSS and linting CSS with GitHub Actions.
 
@@ -21,7 +21,7 @@ Includes support for importing Bootstrap via `node_modules`, adding your own cus
 - Includes [Bootstrap Icons](https://icons.getbootstrap.com) (v1.5.0), which includes over 1,300 icons available as SVGs and web fonts.
 - npm scripts (see `package.json`) for compiling and autoprefixing Sass, watching for changes, and starting a basic local server.
 - Example stylesheet (`scss/starter.scss`) highlighting two ways to include and customize Bootstrap.
-- Example JavaScript file (`assets/js/starter.js`) showing how to import all of Bootstrap, or just the parts you need.
+- Example JavaScript file (`main.js`) showing how to import all of Bootstrap, or just the parts you need.
 
 ## Usage
 
@@ -35,20 +35,20 @@ cd bootstrap-npm-starter
 # Install dependencies
 npm i
 
-# Compile Sass
-npm run css-compile
+# Start the dev server (uses vite)
+# First run has a small delay as a cache is built. Any changes to files are hot reloaded.
+npm run dev
 
-# Watch Sass for changes (uses nodemon)
-npm run watch
+# Build release (uses vite)
+npm run build
 
-# Start local server (uses sirv-cli)
+# Start local server (uses vite)
 npm run server
 
-# Watches Sass for changes and starts a local server
-npm start
 ```
 
-For the most straightforward development, open two Terminal tabs to execute `npm run server` and `npm run watch` at the same time.
+For the most straightforward development, open a Terminal tabs to execute `npm run dev` or `vite`.
+The browser will update will changes to index.html, main.js or starter.scss
 
 Open <http://localhost:3000> to see the page in action.
 
@@ -70,6 +70,8 @@ The following npm scripts are available to you in this starter repo. With the ex
 ## Advanced usage
 
 Take this starter repository to another level with some built-in addons that you can enable and customize.
+
+## Vite uses rollup under the hood and tree-shaking for the js... what follows may not be relevant!
 
 ### Optimizing CSS
 

--- a/index.html
+++ b/index.html
@@ -3,25 +3,42 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="assets/css/starter.css">
     <title>Bootstrap npm starter</title>
   </head>
   <body>
-    <div class="col-md-8 py-4 px-3 mx-auto">
+    <div class="col-md-8 py-5 px-3 mx-auto">
 
-      <header class="d-flex flex-md-row justify-content-md-between align-items-md-center pb-3 mb-5 border-bottom">
+      <header class="pb-3 mb-5 border-bottom">
         <h1 class="h4">
+          <a href="https://vitejs.dev/" class="float-end">
+            <svg height="32" viewBox="0 0 410 404" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M399.641 59.5246L215.643 388.545C211.844 395.338 202.084 395.378 198.228 388.618L10.5817 59.5563C6.38087 52.1896 12.6802 43.2665 21.0281 44.7586L205.223 77.6824C206.398 77.8924 207.601 77.8904 208.776 77.6763L389.119 44.8058C397.439 43.2894 403.768 52.1434 399.641 59.5246Z" fill="url(#paint0_linear)"/>
+              <path d="M292.965 1.5744L156.801 28.2552C154.563 28.6937 152.906 30.5903 152.771 32.8664L144.395 174.33C144.198 177.662 147.258 180.248 150.51 179.498L188.42 170.749C191.967 169.931 195.172 173.055 194.443 176.622L183.18 231.775C182.422 235.487 185.907 238.661 189.532 237.56L212.947 230.446C216.577 229.344 220.065 232.527 219.297 236.242L201.398 322.875C200.278 328.294 207.486 331.249 210.492 326.603L212.5 323.5L323.454 102.072C325.312 98.3645 322.108 94.137 318.036 94.9228L279.014 102.454C275.347 103.161 272.227 99.746 273.262 96.1583L298.731 7.86689C299.767 4.27314 296.636 0.855181 292.965 1.5744Z" fill="url(#paint1_linear)"/>
+              <defs>
+              <linearGradient id="paint0_linear" x1="6.00017" y1="32.9999" x2="235" y2="344" gradientUnits="userSpaceOnUse">
+              <stop stop-color="#41D1FF"/>
+              <stop offset="1" stop-color="#BD34FE"/>
+              </linearGradient>
+              <linearGradient id="paint1_linear" x1="194.651" y1="8.81818" x2="236.076" y2="292.989" gradientUnits="userSpaceOnUse">
+              <stop stop-color="#FFEA83"/>
+              <stop offset="0.0833333" stop-color="#FFDD35"/>
+              <stop offset="1" stop-color="#FFA800"/>
+              </linearGradient>
+              </defs>
+              </svg>
+              Now with Vite!
+            </a>
           <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
             <svg xmlns="http://www.w3.org/2000/svg" width="40" height="32" class="d-inline-block me-2" viewBox="0 0 118 94" role="img"><path fill-rule="evenodd" clip-rule="evenodd" d="M24.509 0c-6.733 0-11.715 5.893-11.492 12.284.214 6.14-.064 14.092-2.066 20.577C8.943 39.365 5.547 43.485 0 44.014v5.972c5.547.529 8.943 4.649 10.951 11.153 2.002 6.485 2.28 14.437 2.066 20.577C12.794 88.106 17.776 94 24.51 94H93.5c6.733 0 11.714-5.893 11.491-12.284-.214-6.14.064-14.092 2.066-20.577 2.009-6.504 5.396-10.624 10.943-11.153v-5.972c-5.547-.529-8.934-4.649-10.943-11.153-2.002-6.484-2.28-14.437-2.066-20.577C105.214 5.894 100.233 0 93.5 0H24.508zM80 57.863C80 66.663 73.436 72 62.543 72H44a2 2 0 01-2-2V24a2 2 0 012-2h18.437c9.083 0 15.044 4.92 15.044 12.474 0 5.302-4.01 10.049-9.119 10.88v.277C75.317 46.394 80 51.21 80 57.863zM60.521 28.34H49.948v14.934h8.905c6.884 0 10.68-2.772 10.68-7.727 0-4.643-3.264-7.207-9.012-7.207zM49.948 49.2v16.458H60.91c7.167 0 10.964-2.876 10.964-8.281 0-5.406-3.903-8.178-11.425-8.178H49.948z" fill="currentColor"></path></svg>
             <span>npm starter</span>
+
           </a>
         </h1>
-        <a href="https://github.com/twbs/bootstrap-npm-starter" target="_blank">View on GitHub</a>
       </header>
 
-      <h1>Get started with Bootstrap</h1>
+      <h1>Get started with Bootstrap + Vite</h1>
       <div class="col-lg-8 px-0">
-        <p class="fs-4">You've successfully loaded up the Bootstrap npm starter project! It's loaded up with <a href="https://getbootstrap.com/docs/5.1/getting-started/introduction/">Bootstrap 5</a>, <a href="https://icons.getbootstrap.com/">Bootstrap Icons</a>, and tooling for compiling our Sass and JavaScript to your needs.</p>
+        <p class="fs-4">You've successfully loaded up the Bootstrap npm starter project! It's loaded up with <a href="https://getbootstrap.com/docs/5.0/getting-started/introduction/">Bootstrap 5</a>, <a href="https://icons.getbootstrap.com/">Bootstrap Icons</a>, and tooling for compiling our Sass and JavaScript to your needs.</p>
         <p>If this button appears blue and the link appears purple, you've done it!</p>
       </div>
 
@@ -85,6 +102,6 @@
       <p class="text-muted">Created and open sourced by the Bootstrap team. Licensed MIT.</p>
     </div>
 
-    <script type="module" src="assets/js/starter.js"></script>
+    <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,26 @@
+import './scss/starter.scss';
+
+// Option 1
+//
+// Import Bootstrap's bundle (all of Bootstrap's JS + Popper.js dependency)
+
+// import * as bootstrap from 'bootstrap';
+
+
+// Option 2
+//
+// Import just what we need
+
+// If you're importing tooltips or popovers, be sure to include our Popper.js dependency
+import "@popperjs/core/dist/umd/popper.min.js";
+
+// Import the required DOM management plugins first
+import "bootstrap/js/dist/dom/data.js";
+import "bootstrap/js/dist/dom/event-handler.js";
+import "bootstrap/js/dist/dom/manipulator.js";
+import "bootstrap/js/dist/dom/selector-engine.js";
+import "bootstrap/js/dist/base-component.js";
+
+// Then your specific components
+import "bootstrap/js/dist/dropdown.js";
+import "bootstrap/js/dist/offcanvas.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1242,6 +1242,12 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "esbuild": {
+      "version": "0.12.24",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.24.tgz",
+      "integrity": "sha512-C0ibY+HsXzYB6L/pLWEiWjMpghKsIc58Q5yumARwBQsHl9DXPakW+5NI/Y9w4YXiz0PEP6XTGTT/OV4Nnsmb4A==",
+      "dev": true
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -3697,6 +3703,15 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup": {
+      "version": "2.56.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
+      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4946,6 +4961,19 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "vite": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.5.2.tgz",
+      "integrity": "sha512-JK5uhiVyMqHiAJbgBa8rCvpP8bEhAE9dKDv1gCmP+EUP2FSPmEeW3WXlCXauPB3MDa8behPW+ntyNXqnGaxslg==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.12.17",
+        "fsevents": "~2.3.2",
+        "postcss": "^8.3.6",
+        "resolve": "^1.20.0",
+        "rollup": "^2.38.5"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   },
   "homepage": "https://github.com/twbs/bootstrap-npm-starter#readme",
   "scripts": {
-    "build": "npm run css",
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview",
+    "css-build": "npm run css",
     "css-compile": "sass --style compressed --source-map --embed-sources --no-error-css --load-path=node_modules scss/:assets/css/",
     "css-lint": "stylelint scss/",
     "css-prefix": "postcss --replace assets/css/starter.css --use autoprefixer --map",
@@ -27,6 +30,7 @@
   },
   "keywords": [
     "bootstrap",
+    "vite",
     "sass",
     "css",
     "javascript",
@@ -48,6 +52,7 @@
     "sass": "^1.38.2",
     "serve": "^12.0.0",
     "stylelint": "^13.13.1",
-    "stylelint-config-twbs-bootstrap": "^2.2.3"
+    "stylelint-config-twbs-bootstrap": "^2.2.3",
+    "vite": "^2.5.2"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+export default {
+  server: {
+    open: '/', // auto open browser in dev mode
+    host: true // and on dev ip
+  }
+}


### PR DESCRIPTION
This PR clones the v5 branch and changes the build tools to use Vite.
It's incredibly quick with hot module replacement for html/scss/js files.

### development
`npm run dev`
The browser is launched and source files are watched for changes. On save the browser will update.

### production build
`npm run build`
The js will be tree-shaken and production ready files saved to `dist`

### Staging preview
`npm run serve`
The pages from `dist` are launched for preview.


